### PR TITLE
Support for reading / extracting RtMI's .ggpack-files and ggdicts 

### DIFF
--- a/cmd/ggdict/main.go
+++ b/cmd/ggdict/main.go
@@ -48,11 +48,12 @@ Usage:
     ggdict -to-json|-from-json path
 
 Flags:
-    -to-json    Converts the given GGDictionary file to JSON format on
-                standard output.
-    -from-json  Converts the given JSON file to GGDictionary format on
-                standard output. You might want to redirect it to a file,
-                since it is a binary format.
+    -to-json        Converts the given GGDictionary file to JSON format on
+                	standard output.
+    -from-json      Converts the given JSON file to GGDictionary format on
+                	standard output. You might want to redirect it to a file,
+                	since it is a binary format.
+    -monkey-island	Use the new format used in Return to Monkey Island
 
 Examples:
     ggdict -to-json Example.wimpy > Example.wimpy.json
@@ -63,6 +64,7 @@ Examples:
 func main() {
 	ggdictFilePath := flag.String("to-json", "", "")
 	jsonFilePath := flag.String("from-json", "", "")
+	monkeyIslandMode := flag.Bool("monkey-island", false, "")
 
 	flag.Usage = usage
 	flag.Parse()
@@ -75,7 +77,7 @@ func main() {
 	}
 
 	if *ggdictFilePath != "" {
-		toJSON(*ggdictFilePath)
+		toJSON(*ggdictFilePath, *monkeyIslandMode)
 		return
 	}
 
@@ -85,10 +87,10 @@ func main() {
 	}
 }
 
-func toJSON(path string) {
+func toJSON(path string, monkeyIslandMode bool) {
 	buf, err := os.ReadFile(path)
 	check(err)
-	dict, err := ggdict.Unmarshal(buf)
+	dict, err := ggdict.Unmarshal(buf, monkeyIslandMode)
 	check(err)
 	jsonData, err := json.MarshalIndent(dict, "", "  ")
 	check(err)

--- a/cmd/ggpack/main.go
+++ b/cmd/ggpack/main.go
@@ -54,7 +54,11 @@ Flags:
     -create   Create a new pack and add the files from the file system
               matching the pattern.
     -key      Name of the key to decrypt/encrypt the data via XOR.
-              Possible names: 56ad (default), 5bad, 566d, 5b6d, delores
+              Possible names: 56ad (default), 5bad, 566d, 5b6d, delores, rtmi
+
+              Note: Return to Monkey Island's key is extracted from the game's 
+              executable which is assumed to be located in the same directory as
+              the pack's file name.
 
 Examples:
     ggpack -list "*" ExamplePackage.ggpack1
@@ -107,6 +111,13 @@ func main() {
 	key, ok := xor.KnownKeys[strings.ToLower(*keyName)]
 	if !ok {
 		fail("Unknown XOR key name: \"" + *keyName + "\"")
+	}
+
+	if key.NeedsLoading() {
+		err := key.LoadKey(packFile)
+		if err != nil {
+			fail("XOR key could not be loaded. Please make sure that your pack file is located in the same directory as the game's executable.")
+		}
 	}
 
 	if *createPattern != "" {
@@ -172,7 +183,7 @@ func extract(pack *ggpack.Pack, filename string) {
 	check(err)
 }
 
-func create(packFilePath string, paths []string, key *xor.Key) error {
+func create(packFilePath string, paths []string, key xor.KeyInterface) error {
 	packFile, err := os.Create(packFilePath)
 	if err != nil {
 		return fmt.Errorf("could not create pack file: %w", err)

--- a/crypt/xor/key.go
+++ b/crypt/xor/key.go
@@ -5,45 +5,160 @@
 // Package xor encodes/decodes data with "unbreakable" XOR encryption.
 package xor
 
+import (
+	"crypto/md5"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/fzipp/gg/crypt/internal/transform"
+)
+
+type KeyInterface interface {
+	newDecoder(expectedSize int64) transform.Transformer
+	DecodingReader(r io.Reader, expectedSize int64) io.Reader
+	newEncoder(expectedSize int64) transform.Transformer
+	EncodingWriter(w io.Writer, expectedSize int64) io.Writer
+	NeedsLoading() bool
+	LoadKey(packFileName string) error
+	UsesShortKeyIndices() bool
+}
+
 type Key struct {
 	MagicBytes []byte
 	Multiplier byte
+}
+
+// Special Key for RtMI contains two byte arrays.
+type MonkeyIslandKey struct {
+	MagicBytes1 [256]byte
+	MagicBytes2 [65536]byte
+	Modifier    byte
+	loaded      bool
+}
+
+func (key *Key) NeedsLoading() bool {
+	return false
+}
+
+func (key *Key) LoadKey(packFileName string) error {
+	return errors.New("this Key does not need to be loaded")
+}
+
+func (key *Key) UsesShortKeyIndices() bool {
+	return false
+}
+
+func (key *MonkeyIslandKey) UsesShortKeyIndices() bool {
+	return true
+}
+
+func (key *MonkeyIslandKey) NeedsLoading() bool {
+	return !key.loaded
+}
+
+func (key *MonkeyIslandKey) LoadKey(packFileName string) error {
+	if key.loaded {
+		return errors.New("this Key does not need to be loaded")
+	}
+
+	packFileName, err := filepath.Abs(packFileName)
+	if err != nil {
+		return err
+	}
+
+	directory := filepath.Dir(packFileName)
+
+	gameExecutableName := filepath.Join(directory, "Return to Monkey Island.exe")
+
+	if _, err := os.Stat(gameExecutableName); errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	data, err := ioutil.ReadFile(gameExecutableName)
+	if err != nil {
+		return err
+	}
+
+	isMatch := func(firstValue byte, length int, checksum [16]byte, startIndex int) bool {
+		if data[startIndex] != firstValue {
+			return false
+		}
+		sum := md5.Sum(data[startIndex:(length + startIndex)])
+		for i := 0; i < 16; i++ {
+			if sum[i] != checksum[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	found1 := false
+	found2 := false
+
+	for i := 0; i < len(data)-256; i++ {
+		if isMatch(0xD5, 256, [16]byte{0xB1, 0x90, 0xC4, 0x21, 0xFE, 0x7F, 0xEA, 0xFC, 0x77, 0xC5, 0x17, 0xA2, 0x32, 0xAB, 0xBB, 0x4C}, i) {
+			for x := 0; x < 256; x++ {
+				key.MagicBytes1[x] = data[i+x]
+			}
+			found1 = true
+			break
+		}
+	}
+
+	for i := 0; i < len(data)-65536; i++ {
+		if isMatch(0xF7, 65536, [16]byte{0x7F, 0xAA, 0xF6, 0x57, 0x4F, 0x27, 0xEB, 0xD9, 0xD2, 0x74, 0x4C, 0xC6, 0x8E, 0x41, 0x15, 0xC8}, i) {
+			for x := 0; x < 65536; x++ {
+				key.MagicBytes2[x] = data[i+x]
+			}
+			found2 = true
+			break
+		}
+	}
+
+	if !found1 || !found2 {
+		return errors.New("one or both keys could not be found")
+	}
+
+	return nil
 }
 
 // KnownKeys is a collection of XOR keys for ggpack files found in the wild.
 // These keys differ slightly at MagicBytes[5] (0x5B vs. 0x56) and regarding
 // the multiplier (0x6D vs. 0xAD). This is reflected in the names (e.g. "56ad")
 // by which they can be referenced.
-var KnownKeys = map[string]*Key{
-	"5b6d": {
+var KnownKeys = map[string]KeyInterface{
+	"5b6d": &Key{
 		MagicBytes: []byte{
 			0x4F, 0xD0, 0xA0, 0xAC, 0x4A, 0x5B, 0xB9, 0xE5,
 			0x93, 0x79, 0x45, 0xA5, 0xC1, 0xCB, 0x31, 0x93,
 		},
 		Multiplier: 0x6D,
 	},
-	"566d": {
+	"566d": &Key{
 		MagicBytes: []byte{
 			0x4F, 0xD0, 0xA0, 0xAC, 0x4A, 0x56, 0xB9, 0xE5,
 			0x93, 0x79, 0x45, 0xA5, 0xC1, 0xCB, 0x31, 0x93,
 		},
 		Multiplier: 0x6D,
 	},
-	"5bad": {
+	"5bad": &Key{
 		MagicBytes: []byte{
 			0x4F, 0xD0, 0xA0, 0xAC, 0x4A, 0x5B, 0xB9, 0xE5,
 			0x93, 0x79, 0x45, 0xA5, 0xC1, 0xCB, 0x31, 0x93,
 		},
 		Multiplier: 0xAD,
 	},
-	"56ad": {
+	"56ad": &Key{
 		MagicBytes: []byte{
 			0x4F, 0xD0, 0xA0, 0xAC, 0x4A, 0x56, 0xB9, 0xE5,
 			0x93, 0x79, 0x45, 0xA5, 0xC1, 0xCB, 0x31, 0x93,
 		},
 		Multiplier: 0xAD,
 	},
-	"delores": {
+	"delores": &Key{
 		MagicBytes: []byte{
 			0x3F, 0x41, 0x41, 0x60, 0x95, 0x87, 0x4A, 0xE6,
 			0x34, 0xC6, 0x3A, 0x86, 0x29, 0x27, 0x77, 0x8D,
@@ -53,6 +168,10 @@ var KnownKeys = map[string]*Key{
 			0x00, 0xE4, 0x40, 0xC6, 0x00, 0xE4, 0x40, 0xC6,
 		},
 		Multiplier: 0x6D,
+	},
+	"rtmi": &MonkeyIslandKey{
+		Modifier: 0x78,
+		loaded:   false,
 	},
 }
 

--- a/crypt/xor/roundtrip_test.go
+++ b/crypt/xor/roundtrip_test.go
@@ -17,14 +17,14 @@ func TestWriterReaderRoundTrip(t *testing.T) {
 
 	original := []byte("This is a test.")
 	encodedBuf := &bytes.Buffer{}
-	_, err := xor.EncodingWriter(encodedBuf, key, int64(len(original))).Write(original)
+	_, err := key.EncodingWriter(encodedBuf, int64(len(original))).Write(original)
 	if err != nil {
 		t.Errorf("encoding writer returned an error: %s", err)
 	}
 	encoded := encodedBuf.Bytes()
 
 	decoded := make([]byte, len(encoded))
-	_, err = xor.DecodingReader(bytes.NewBuffer(encoded), key, int64(len(encoded))).Read(decoded)
+	_, err = key.DecodingReader(bytes.NewBuffer(encoded), int64(len(encoded))).Read(decoded)
 	if err != nil {
 		t.Errorf("decoding reader returned an error: %s", err)
 	}

--- a/ggdict/marshal.go
+++ b/ggdict/marshal.go
@@ -107,6 +107,7 @@ func (m *marshaller) writeFloat(f float64) {
 }
 
 func (m *marshaller) writeKeyIndex(key string) {
+	// Todo: writing new files  with 16 bit string indices (as used in RtMI)
 	offset, ok := m.keyIndex[key]
 	if !ok {
 		offset = len(m.keys)

--- a/ggdict/roundtrip_test.go
+++ b/ggdict/roundtrip_test.go
@@ -23,7 +23,7 @@ func TestRoundTrip(t *testing.T) {
 		"nothing": nil,
 	}
 	data := ggdict.Marshal(dict)
-	newDict, err := ggdict.Unmarshal(data)
+	newDict, err := ggdict.Unmarshal(data, false)
 	if err != nil {
 		t.Errorf("Unmarshal returned an error: %s", err)
 		return

--- a/ggdict/unmarshal_test.go
+++ b/ggdict/unmarshal_test.go
@@ -91,7 +91,7 @@ func TestUnmarshalErrors(t *testing.T) {
 		}, `could not read root: could not read dictionary value for key "a": could not read array value: unknown value type: 0`},
 	}
 	for _, tt := range tests {
-		_, err := ggdict.Unmarshal(tt.data)
+		_, err := ggdict.Unmarshal(tt.data, false)
 		if err == nil {
 			t.Errorf("expected error for unmarshalling of %#v, but no error returned", tt.data)
 			continue

--- a/ggpack/directory.go
+++ b/ggpack/directory.go
@@ -86,8 +86,8 @@ const (
 	keySize     = "size"
 )
 
-func readDirectory(buf []byte, root *fileInfo) (*directory, error) {
-	directoryDict, err := ggdict.Unmarshal(buf)
+func readDirectory(buf []byte, root *fileInfo, shortStringIndices bool) (*directory, error) {
+	directoryDict, err := ggdict.Unmarshal(buf, shortStringIndices)
 	if err != nil {
 		return nil, fmt.Errorf("could not read directory: %w", err)
 	}

--- a/savegame/savegame.go
+++ b/savegame/savegame.go
@@ -43,7 +43,7 @@ func Read(r io.Reader) (map[string]any, error) {
 	if !isChecksumOk(decrypted) {
 		return nil, fmt.Errorf("invalid checksum for savegame data")
 	}
-	dict, err := ggdict.Unmarshal(decrypted)
+	dict, err := ggdict.Unmarshal(decrypted, false) // Todo: RtMI?
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal savegame data: %w", err)
 	}

--- a/wimpy/read.go
+++ b/wimpy/read.go
@@ -20,7 +20,7 @@ func Read(r io.Reader) (*Room, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read wimpy data: %w", err)
 	}
-	dict, err := ggdict.Unmarshal(buf.Bytes())
+	dict, err := ggdict.Unmarshal(buf.Bytes(), false) // Todo: Rtmi?
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal wimpy dictionary: %w", err)
 	}


### PR DESCRIPTION
Hello,
I have modified the program to open Return to Monkey Island's .ggpack*-files and to decode the changes in the ggdict-format.
(Note: first time working with go.)

- Implemented the new XOR-Algorithm used by RtMI, keys are extracted from the game's executable file. (2 keys: 256 and 65536 bytes in length)
- RtMI's GGDicts use 16 bits for each string value instead of 32 bit. This change is automatically selected in ggpack (when using the rtmi-key) and selected via a new parameter in ggdict. 

The other tools may still need changes, and packing new ggpacks / ggdicts are not yet implemented.